### PR TITLE
[FE] 칼럼카드 추가 및 수정 UI 구현

### DIFF
--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { styled } from "styled-components";
-import ColumnCard from "./ColumnCard.tsx";
+import ColumnCard from "./ColumnCard/ColumnCard.tsx";
+import NewColumnCard from "./ColumnCard/NewColumnCard.tsx";
 import IconButton from "./common/IconButton.tsx";
 import addButtonIcon from "../assets/plus.svg";
 import deleteButtonIcon from "../assets/closed.svg";
@@ -28,6 +29,7 @@ export default function Column() {
       </Header>
 
       <ul className="cards-list">
+        <NewColumnCard />
         <ColumnCard />
         <ColumnCard />
       </ul>

--- a/frontend/src/components/ColumnCard/ColumnCard.tsx
+++ b/frontend/src/components/ColumnCard/ColumnCard.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from "react";
+import { styled } from "styled-components";
+import ColumnCardDisplay from "./ColumnCardDisplay.tsx";
+import ColumnCardMode from "./ColumnCardMode.tsx";
+
+export default function ColumnCard() {
+  const [isEditMode, setIsEditMode] = useState<boolean>(false);
+
+  return (
+    <StyledColumnCard>
+      {isEditMode ? <ColumnCardMode mode="edit" /> : <ColumnCardDisplay />}
+    </StyledColumnCard>
+  );
+}
+
+const StyledColumnCard = styled.li`
+  width: 100%;
+  min-height: 104px;
+  padding: 16px;
+  background-color: ${({ theme: { colors } }) => colors.grey50};
+  border-radius: ${({ theme: { objectStyles } }) => objectStyles.radius.s};
+  box-shadow: ${({ theme: { objectStyles } }) =>
+    objectStyles.dropShadow.normal};
+`;

--- a/frontend/src/components/ColumnCard/ColumnCardDisplay.tsx
+++ b/frontend/src/components/ColumnCard/ColumnCardDisplay.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { styled } from "styled-components";
-import IconButton from "./common/IconButton.tsx";
-import deleteButtonIcon from "../assets/closed.svg";
-import editButtonIcon from "../assets/edit.svg";
+import IconButton from "../common/IconButton.tsx";
+import deleteButtonIcon from "../../assets/closed.svg";
+import editButtonIcon from "../../assets/edit.svg";
 
-export default function ColumnCard() {
+export default function ColumnCardDisplay() {
   return (
-    <StyledColumnCard>
+    <StyledColumnCardDisplay>
       <div className="card-info-container">
-        <h3>Card title</h3>
+        <h3 className="card-title">Card title</h3>
         <p className="card-content">Card content</p>
         <p className="card-author">author by web</p>
       </div>
@@ -25,34 +25,31 @@ export default function ColumnCard() {
           alt="카드 수정"
         />
       </div>
-    </StyledColumnCard>
+    </StyledColumnCardDisplay>
   );
 }
 
-const StyledColumnCard = styled.li`
+const StyledColumnCardDisplay = styled.div`
   width: 100%;
-  padding: 16px;
+  height: 100%;
   display: flex;
-  justify-content: space-between;
   gap: 16px;
-  background-color: ${({ theme: { colors } }) => colors.grey50};
-  border-radius: ${({ theme: { objectStyles } }) => objectStyles.radius.s};
-  box-shadow: ${({ theme: { objectStyles } }) =>
-    objectStyles.dropShadow.normal};
 
   .card-info-container {
     flex-grow: 1;
 
-    h3 {
+    .card-title {
       margin-bottom: 8px;
       font: ${({ theme: { font } }) => font.displayBold14};
       color: ${({ theme: { colors } }) => colors.grey900};
+      overflow-wrap: anywhere;
     }
 
     .card-content {
       margin-bottom: 16px;
       font: ${({ theme: { font } }) => font.displayMD14};
       color: ${({ theme: { colors } }) => colors.grey600};
+      overflow-wrap: anywhere;
     }
 
     .card-author {

--- a/frontend/src/components/ColumnCard/ColumnCardMode.tsx
+++ b/frontend/src/components/ColumnCard/ColumnCardMode.tsx
@@ -1,0 +1,95 @@
+import React, { FormEvent } from "react";
+import { styled } from "styled-components";
+import ActionButton from "../common/ActionButton.tsx";
+
+const ModeKR = {
+  add: "등록",
+  edit: "저장",
+};
+
+export default function ColumnCardMode({ mode }: { mode: "add" | "edit" }) {
+  // TODO: `.card-title` input state
+  // TODO: `.card-content` input state
+
+  const submitHandler = (evt: FormEvent) => {
+    evt.preventDefault();
+  };
+
+  return (
+    <StyledColumnCardMode onSubmit={submitHandler}>
+      <div className="card-info-container">
+        <input
+          className="card-title"
+          type="text"
+          placeholder="제목을 입력하세요"
+        />
+        <textarea
+          className="card-content"
+          placeholder="내용을 입력하세요"
+          rows={1}
+        />
+      </div>
+
+      <div className="buttons-container">
+        <ActionButton className="cancel-button" content="취소" type="button" />
+        <ActionButton
+          className={`${mode}-button`}
+          content={ModeKR[mode]}
+          type="submit"
+          disabled={"" == ""} // TODO: if `.card-title` or `.card-content` is empty, `disabled`.
+        />
+      </div>
+    </StyledColumnCardMode>
+  );
+}
+
+const StyledColumnCardMode = styled.form`
+  width: 100%;
+  height: 100%;
+
+  .card-info-container {
+    flex-grow: 1;
+
+    .card-title {
+      width: 100%;
+      margin-bottom: 8px;
+      background: transparent;
+      border: none;
+      font: ${({ theme: { font } }) => font.displayBold14};
+      color: ${({ theme: { colors } }) => colors.grey900};
+
+      &::placeholder {
+        font: ${({ theme: { font } }) => font.displayBold14};
+        color: ${({ theme: { colors } }) => colors.grey900};
+      }
+    }
+
+    .card-content {
+      width: 100%;
+      max-height: 200px;
+      margin-bottom: 16px;
+      background: transparent;
+      border: none;
+      font: ${({ theme: { font } }) => font.displayMD14};
+      color: ${({ theme: { colors } }) => colors.grey600};
+      resize: vertical;
+      overflow: auto;
+      cursor: text;
+
+      &::placeholder {
+        font: ${({ theme: { font } }) => font.displayMD14};
+        color: ${({ theme: { colors } }) => colors.grey600};
+      }
+    }
+
+    .card-author {
+      font: ${({ theme: { font } }) => font.displayMD12};
+      color: ${({ theme: { colors } }) => colors.grey500};
+    }
+  }
+
+  .buttons-container {
+    display: flex;
+    gap: 8px;
+  }
+`;

--- a/frontend/src/components/ColumnCard/NewColumnCard.tsx
+++ b/frontend/src/components/ColumnCard/NewColumnCard.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { styled } from "styled-components";
+import ColumnCardMode from "./ColumnCardMode.tsx";
+
+export default function NewColumnCard() {
+  return (
+    <StyledNewColumnCard>
+      <ColumnCardMode mode="add" />
+    </StyledNewColumnCard>
+  );
+}
+
+const StyledNewColumnCard = styled.li`
+  width: 100%;
+  min-height: 104px;
+  padding: 16px;
+  background-color: ${({ theme: { colors } }) => colors.grey50};
+  border-radius: ${({ theme: { objectStyles } }) => objectStyles.radius.s};
+  box-shadow: ${({ theme: { objectStyles } }) =>
+    objectStyles.dropShadow.normal};
+`;

--- a/frontend/src/components/common/ActionButton.tsx
+++ b/frontend/src/components/common/ActionButton.tsx
@@ -4,14 +4,24 @@ import { styled } from "styled-components";
 export default function ActionButton({
   className,
   content,
+  type,
+  disabled,
 }: {
   className: string;
   content: string;
+  type: "button" | "submit" | "reset";
+  disabled?: boolean;
 }) {
   return (
-    <StyledActionButton className={className}>{content}</StyledActionButton>
+    <StyledActionButton {...{ className, type, disabled }}>
+      {content}
+    </StyledActionButton>
   );
 }
+
+ActionButton.defaultProps = {
+  disabled: false,
+};
 
 const StyledActionButton = styled.button`
   width: 132px;
@@ -28,7 +38,8 @@ const StyledActionButton = styled.button`
     color: ${({ theme: { colors } }) => colors.grey600};
   }
 
-  &.add-button {
+  &.add-button,
+  &.edit-button {
     background-color: ${({ theme: { colors } }) => colors.blue};
     color: ${({ theme: { colors } }) => colors.grey50};
   }
@@ -36,5 +47,10 @@ const StyledActionButton = styled.button`
   &.delete-button {
     background-color: ${({ theme: { colors } }) => colors.red};
     color: ${({ theme: { colors } }) => colors.grey50};
+  }
+
+  &:disabled {
+    opacity: ${({ theme: { opacity } }) => opacity.disabled};
+    cursor: not-allowed;
   }
 `;


### PR DESCRIPTION
## What is this PR? 👓
- 칼럼카드 display, edit, add 모드 구현.

## Key changes 🔑
- `<ColumnCard />`
  - `<ColumnCardDisplay />` or `<ColumnCardMode mode="edit" />`
- `<NewColumnCard />`
  - `<ColumnCardMode mode="add" />`

- 일반 모드는 다른 모드 대비 내용 및 스타일 차이가 많기 때문에 따로 `ColumnCardDisplay` 컴포넌트를 따로 구현.
- 추가 모드와 수정 모드의 스타일이 동일하고 내용만 조금의 차이가 있기 때문에 `ColumnCardMode`를 재사용.
- `ColumnCard`와 `NewColumnCard` 구분을 한 이유는 `ColumnCard`에서 추가 모드까지 고려하는 것은 부적절하고 불필요하게 복잡해진다고 판단.
- `ActionButton`에 button `type`, `disabled` props 추가.

## To reviewers 👋
- Use case에 맞게 칼럼카드 컴포넌트화와 재사용에 대한 고민이 있었습니다.

## Issues
