### PR TITLE
[BE] 카드 조회 API 구현

### DIFF
--- a/be/.gitignore
+++ b/be/.gitignore
@@ -37,4 +37,6 @@ out/
 .vscode/
 
 src/main/resources/application-local.yml
+src/main/resources/application-release.yml
+src/main/resources/application-prod.yml
 src/main/resources/db/

--- a/be/build.gradle
+++ b/be/build.gradle
@@ -17,11 +17,18 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// 어노테이션 프로세서 활성화
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }

--- a/be/build.gradle
+++ b/be/build.gradle
@@ -32,3 +32,8 @@ configurations {
         extendsFrom annotationProcessor
     }
 }
+
+// plain jar 생성 방지
+jar {
+    enabled = false
+}

--- a/be/src/main/java/codesquad/todo/card/controller/CardListResponse.java
+++ b/be/src/main/java/codesquad/todo/card/controller/CardListResponse.java
@@ -2,10 +2,7 @@ package codesquad.todo.card.controller;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public class CardListResponse {
-	@JsonProperty("column_id")
 	private Long columnId; // 컬럼의 아이디 번호
 
 	private String name; // 컬럼의 제목

--- a/be/src/main/java/codesquad/todo/card/controller/CardListResponse.java
+++ b/be/src/main/java/codesquad/todo/card/controller/CardListResponse.java
@@ -1,0 +1,32 @@
+package codesquad.todo.card.controller;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CardListResponse {
+	@JsonProperty("column_id")
+	private Long columnId; // 컬럼의 아이디 번호
+
+	private String name; // 컬럼의 제목
+
+	List<CardSearchResponse> cards;
+
+	public CardListResponse(Long columnId, String name, List<CardSearchResponse> cards) {
+		this.columnId = columnId;
+		this.name = name;
+		this.cards = cards;
+	}
+
+	public Long getColumnId() {
+		return columnId;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public List<CardSearchResponse> getCards() {
+		return cards;
+	}
+}

--- a/be/src/main/java/codesquad/todo/card/controller/CardRestController.java
+++ b/be/src/main/java/codesquad/todo/card/controller/CardRestController.java
@@ -1,5 +1,8 @@
 package codesquad.todo.card.controller;
 
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import codesquad.todo.card.service.CardService;
@@ -10,5 +13,10 @@ public class CardRestController {
 
 	public CardRestController(CardService cardService) {
 		this.cardService = cardService;
+	}
+
+	@GetMapping("/cards")
+	public List<CardListResponse> list() {
+		return cardService.getAllCard();
 	}
 }

--- a/be/src/main/java/codesquad/todo/card/controller/CardSearchResponse.java
+++ b/be/src/main/java/codesquad/todo/card/controller/CardSearchResponse.java
@@ -1,7 +1,5 @@
 package codesquad.todo.card.controller;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import codesquad.todo.card.entity.Card;
 
 public class CardSearchResponse {
@@ -9,7 +7,6 @@ public class CardSearchResponse {
 	private String title;
 	private String content;
 	private int position;
-	@JsonProperty("column_id")
 	private Long columnId;
 
 	public CardSearchResponse(Long id, String title, String content, int position, Long columnId) {

--- a/be/src/main/java/codesquad/todo/card/controller/CardSearchResponse.java
+++ b/be/src/main/java/codesquad/todo/card/controller/CardSearchResponse.java
@@ -1,0 +1,47 @@
+package codesquad.todo.card.controller;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import codesquad.todo.card.entity.Card;
+
+public class CardSearchResponse {
+	private Long id;
+	private String title;
+	private String content;
+	private int position;
+	@JsonProperty("column_id")
+	private Long columnId;
+
+	public CardSearchResponse(Long id, String title, String content, int position, Long columnId) {
+		this.id = id;
+		this.title = title;
+		this.content = content;
+		this.position = position;
+		this.columnId = columnId;
+	}
+
+	public static CardSearchResponse from(Card card) {
+		return new CardSearchResponse(card.getId(), card.getTitle(), card.getContent(), card.getPosition(),
+			card.getColumnId());
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public int getPosition() {
+		return position;
+	}
+
+	public Long getColumnId() {
+		return columnId;
+	}
+}

--- a/be/src/main/java/codesquad/todo/card/entity/Card.java
+++ b/be/src/main/java/codesquad/todo/card/entity/Card.java
@@ -60,7 +60,7 @@ public class Card {
 			'}';
 	}
 
-	static class Builder {
+	public static class Builder {
 		private Long id; // 카드 아이디
 		private String title; // 제목
 		private String content; // 내용

--- a/be/src/main/java/codesquad/todo/card/repository/CardRepository.java
+++ b/be/src/main/java/codesquad/todo/card/repository/CardRepository.java
@@ -15,4 +15,6 @@ public interface CardRepository {
 	Card deleteById(Long id);
 
 	Optional<Card> findById(Long id);
+
+	List<Card> findAllByColumnId(Long columnId);
 }

--- a/be/src/main/java/codesquad/todo/card/repository/JdbcCardRepository.java
+++ b/be/src/main/java/codesquad/todo/card/repository/JdbcCardRepository.java
@@ -3,7 +3,10 @@ package codesquad.todo.card.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
 import codesquad.todo.card.entity.Card;
@@ -19,7 +22,8 @@ public class JdbcCardRepository implements CardRepository {
 
 	@Override
 	public List<Card> findAll() {
-		return null;
+		return template.query("SELECT c.id, c.title, c.content, c.position, c.is_deleted, c.column_id FROM card c",
+			getCardRowMapper());
 	}
 
 	@Override
@@ -41,4 +45,25 @@ public class JdbcCardRepository implements CardRepository {
 	public Optional<Card> findById(Long id) {
 		return Optional.empty();
 	}
+
+	@Override
+	public List<Card> findAllByColumnId(Long columnId) {
+		SqlParameterSource param = new MapSqlParameterSource("column_id", columnId);
+
+		return template.query(
+			"SELECT c.id, c.title, c.content, c.position, c.is_deleted, c.column_id FROM card c WHERE c.column_id = :column_id",
+			param, getCardRowMapper());
+	}
+
+	private RowMapper<Card> getCardRowMapper() {
+		return (rs, rowNum) -> Card.builder()
+			.id(rs.getLong("id"))
+			.title(rs.getString("title"))
+			.content(rs.getString("content"))
+			.position(rs.getInt("position"))
+			.isDeleted(rs.getBoolean("is_deleted"))
+			.columnId(rs.getLong("column_id"))
+			.build();
+	}
+
 }

--- a/be/src/main/java/codesquad/todo/card/repository/JdbcCardRepository.java
+++ b/be/src/main/java/codesquad/todo/card/repository/JdbcCardRepository.java
@@ -22,7 +22,8 @@ public class JdbcCardRepository implements CardRepository {
 
 	@Override
 	public List<Card> findAll() {
-		return template.query("SELECT c.id, c.title, c.content, c.position, c.is_deleted, c.column_id FROM card c",
+		return template.query(
+			"SELECT c.id, c.title, c.content, c.position, c.is_deleted, c.column_id FROM card c WHERE c.is_deleted = FALSE",
 			getCardRowMapper());
 	}
 
@@ -51,7 +52,7 @@ public class JdbcCardRepository implements CardRepository {
 		SqlParameterSource param = new MapSqlParameterSource("column_id", columnId);
 
 		return template.query(
-			"SELECT c.id, c.title, c.content, c.position, c.is_deleted, c.column_id FROM card c WHERE c.column_id = :column_id",
+			"SELECT c.id, c.title, c.content, c.position, c.is_deleted, c.column_id FROM card c WHERE c.column_id = :column_id AND c.is_deleted = FALSE",
 			param, getCardRowMapper());
 	}
 

--- a/be/src/main/java/codesquad/todo/card/service/CardService.java
+++ b/be/src/main/java/codesquad/todo/card/service/CardService.java
@@ -1,15 +1,47 @@
 package codesquad.todo.card.service;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 
+import codesquad.todo.card.controller.CardListResponse;
+import codesquad.todo.card.controller.CardSearchResponse;
+import codesquad.todo.card.entity.Card;
 import codesquad.todo.card.repository.CardRepository;
+import codesquad.todo.column.entity.Column;
+import codesquad.todo.column.repository.ColumnRepository;
 
 @Service
 public class CardService {
 
 	private final CardRepository cardRepository;
+	private final ColumnRepository columnRepository;
 
-	public CardService(CardRepository cardRepository) {
+	public CardService(CardRepository cardRepository, ColumnRepository columnRepository) {
 		this.cardRepository = cardRepository;
+		this.columnRepository = columnRepository;
+	}
+
+	public List<CardListResponse> getAllCard() {
+		List<CardListResponse> cardListResponses = new ArrayList<>();
+		// 1. 모든 카드 조회
+		List<Column> columns = columnRepository.findAll();
+
+		for (Column column : columns) {
+			// 2. 컬럼 아이디에 따른 카드 조회
+			List<CardSearchResponse> cards = cardRepository.findAllByColumnId(column.getId())
+				.stream()
+				.sorted(Comparator.comparingInt(Card::getPosition).reversed())
+				.map(CardSearchResponse::from)
+				.collect(Collectors.toUnmodifiableList());
+
+			// 3. DTO 객체로 변환하여 결과 리스트에 저장
+			cardListResponses.add(new CardListResponse(column.getId(), column.getName(), cards));
+		}
+
+		return cardListResponses;
 	}
 }

--- a/be/src/main/java/codesquad/todo/card/service/CardService.java
+++ b/be/src/main/java/codesquad/todo/card/service/CardService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import codesquad.todo.card.controller.CardListResponse;
 import codesquad.todo.card.controller.CardSearchResponse;
@@ -25,6 +26,7 @@ public class CardService {
 		this.columnRepository = columnRepository;
 	}
 
+	@Transactional(readOnly = true)
 	public List<CardListResponse> getAllCard() {
 		List<CardListResponse> cardListResponses = new ArrayList<>();
 		// 1. 모든 카드 조회

--- a/be/src/main/java/codesquad/todo/column/entity/Column.java
+++ b/be/src/main/java/codesquad/todo/column/entity/Column.java
@@ -32,7 +32,7 @@ public class Column {
 			'}';
 	}
 
-	static class Builder {
+	public static class Builder {
 		private Long id;
 		private String name;
 

--- a/be/src/main/java/codesquad/todo/column/repository/JdbcColumnRepository.java
+++ b/be/src/main/java/codesquad/todo/column/repository/JdbcColumnRepository.java
@@ -3,6 +3,7 @@ package codesquad.todo.column.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -11,11 +12,15 @@ import codesquad.todo.column.entity.Column;
 @Repository
 public class JdbcColumnRepository implements ColumnRepository {
 
-	private NamedParameterJdbcTemplate template;
+	private final NamedParameterJdbcTemplate template;
+
+	public JdbcColumnRepository(NamedParameterJdbcTemplate template) {
+		this.template = template;
+	}
 
 	@Override
 	public List<Column> findAll() {
-		return null;
+		return template.query("SELECT c.id, c.name FROM columns c", getColumnRowMapper());
 	}
 
 	@Override
@@ -36,5 +41,12 @@ public class JdbcColumnRepository implements ColumnRepository {
 	@Override
 	public Optional<Column> findById(Long id) {
 		return Optional.empty();
+	}
+
+	private RowMapper<Column> getColumnRowMapper() {
+		return (rs, rowNum) -> Column.builder()
+			.id(rs.getLong("id"))
+			.name(rs.getString("name"))
+			.build();
 	}
 }

--- a/be/src/main/java/codesquad/todo/column/service/ColumnService.java
+++ b/be/src/main/java/codesquad/todo/column/service/ColumnService.java
@@ -12,4 +12,5 @@ public class ColumnService {
 	public ColumnService(ColumnRepository columnRepository) {
 		this.columnRepository = columnRepository;
 	}
+
 }

--- a/be/src/main/java/codesquad/todo/column/service/ColumnService.java
+++ b/be/src/main/java/codesquad/todo/column/service/ColumnService.java
@@ -12,5 +12,4 @@ public class ColumnService {
 	public ColumnService(ColumnRepository columnRepository) {
 		this.columnRepository = columnRepository;
 	}
-
 }

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -1,1 +1,3 @@
-
+spring:
+  profiles:
+    default: local

--- a/be/src/test/java/codesquad/todo/card/controller/CardRestControllerTest.java
+++ b/be/src/test/java/codesquad/todo/card/controller/CardRestControllerTest.java
@@ -50,15 +50,15 @@ class CardRestControllerTest {
 	@DisplayName("/cards를 요청할때 컬럼별 카드들을 조회한다")
 	public void testCardList() throws Exception {
 		// given
-		String expectByColumnName = "$[%s].name";
-		String expectByColumnId = "$[%s].column_id";
-		String expectByCards = "$[%s].cards";
+		String expectedColumnName = "$[%s].name";
+		String expectedColumnId = "$[%s].column_id";
+		String expectedCards = "$[%s].cards";
 		// when
 		mockMvc.perform(get("/cards"))
 			.andDo(print())
 			.andExpect(status().isOk())
-			.andExpect(jsonPath(expectByColumnName, 0).value(equalTo("해야할 일")))
-			.andExpect(jsonPath(expectByColumnId, 0).value(equalTo(1)))
-			.andExpect(jsonPath(expectByCards, 0).isArray());
+			.andExpect(jsonPath(expectedColumnName, 0).value(equalTo("해야할 일")))
+			.andExpect(jsonPath(expectedColumnId, 0).value(equalTo(1)))
+			.andExpect(jsonPath(expectedCards, 0).isArray());
 	}
 }

--- a/be/src/test/java/codesquad/todo/card/controller/CardRestControllerTest.java
+++ b/be/src/test/java/codesquad/todo/card/controller/CardRestControllerTest.java
@@ -1,5 +1,64 @@
 package codesquad.todo.card.controller;
 
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import codesquad.todo.card.entity.Card;
+import codesquad.todo.card.service.CardService;
+
+@WebMvcTest(CardRestController.class)
 class CardRestControllerTest {
 
+	private MockMvc mockMvc;
+
+	@MockBean
+	private CardService cardService;
+
+	@BeforeEach
+	public void beforeEach() {
+		mockMvc = MockMvcBuilders.standaloneSetup(new CardRestController(cardService))
+			.addFilter(new CharacterEncodingFilter("UTF-8", true))
+			.alwaysExpect(status().isOk())
+			.alwaysDo(print())
+			.build();
+		// mocking
+		List<CardListResponse> cards = new ArrayList<>();
+		List<CardSearchResponse> cardSearches = new ArrayList<>();
+		cardSearches.add(CardSearchResponse.from(new Card(1L, "제목1", "내용1", 0, false, 1L)));
+		cardSearches.add(CardSearchResponse.from(new Card(2L, "제목2", "내용2", 0, false, 1L)));
+		cardSearches.add(CardSearchResponse.from(new Card(3L, "제목3", "내용3", 0, false, 1L)));
+		cards.add(new CardListResponse(1L, "해야할 일", cardSearches));
+		Mockito.when(cardService.getAllCard()).thenReturn(cards);
+	}
+
+	@Test
+	@DisplayName("/cards를 요청할때 컬럼별 카드들을 조회한다")
+	public void testCardList() throws Exception {
+		// given
+		String expectByColumnName = "$[%s].name";
+		String expectByColumnId = "$[%s].column_id";
+		String expectByCards = "$[%s].cards";
+		// when
+		mockMvc.perform(get("/cards"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath(expectByColumnName, 0).value(equalTo("해야할 일")))
+			.andExpect(jsonPath(expectByColumnId, 0).value(equalTo(1)))
+			.andExpect(jsonPath(expectByCards, 0).isArray());
+	}
 }

--- a/be/src/test/java/codesquad/todo/card/controller/CardRestControllerTest.java
+++ b/be/src/test/java/codesquad/todo/card/controller/CardRestControllerTest.java
@@ -51,7 +51,7 @@ class CardRestControllerTest {
 	public void testCardList() throws Exception {
 		// given
 		String expectedColumnName = "$[%s].name";
-		String expectedColumnId = "$[%s].column_id";
+		String expectedColumnId = "$[%s].columnId";
 		String expectedCards = "$[%s].cards";
 		// when
 		mockMvc.perform(get("/cards"))

--- a/be/src/test/java/codesquad/todo/card/repository/JdbcCardRepositoryTest.java
+++ b/be/src/test/java/codesquad/todo/card/repository/JdbcCardRepositoryTest.java
@@ -1,5 +1,53 @@
 package codesquad.todo.card.repository;
 
+import java.util.List;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.stereotype.Repository;
+
+import codesquad.todo.card.entity.Card;
+
+// Repository 애노테이션이 붙은 클래스만 빈으로 등록
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = Repository.class))
+// Replace.NONE으로 설정하면 @ActiveProfiles에 설정한 프로파일 환경값에 따라 데이터소스가 적용된다.
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class JdbcCardRepositoryTest {
 
+	@Autowired
+	private CardRepository cardRepository;
+
+	@Test
+	@DisplayName("모든 카드 데이터를 요청합니다.")
+	public void testFindAll() {
+		// given
+
+		// when
+		List<Card> cards = cardRepository.findAll();
+		// then
+		SoftAssertions.assertSoftly(softAssertions -> {
+			softAssertions.assertThat(cards.size()).isEqualTo(9);
+			softAssertions.assertAll();
+		});
+	}
+
+	@Test
+	@DisplayName("컬럼 아이디에 따른 카드 데이터를 요청합니다.")
+	public void testFindAllByColumnId() {
+		// given
+
+		// when
+		List<Card> cards = cardRepository.findAllByColumnId(1L);
+		// then
+		SoftAssertions.assertSoftly(softAssertions -> {
+			softAssertions.assertThat(cards.size()).isEqualTo(3);
+			softAssertions.assertAll();
+		});
+	}
 }

--- a/be/src/test/java/codesquad/todo/column/repository/JdbcColumnRepositoryTest.java
+++ b/be/src/test/java/codesquad/todo/column/repository/JdbcColumnRepositoryTest.java
@@ -1,5 +1,38 @@
 package codesquad.todo.column.repository;
 
-class JdbcColumnRepositoryTest {
+import java.util.List;
 
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.stereotype.Repository;
+
+import codesquad.todo.column.entity.Column;
+
+// Repository 애노테이션이 붙은 클래스만 빈으로 등록
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = Repository.class))
+// Replace.NONE으로 설정하면 @ActiveProfiles에 설정한 프로파일 환경값에 따라 데이터소스가 적용된다.
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class JdbcColumnRepositoryTest {
+	@Autowired
+	private ColumnRepository columnRepository;
+
+	@Test
+	@DisplayName("모든 컬럼 데이터를 요청한다")
+	public void testFindAll() {
+		// given
+
+		// when
+		List<Column> columns = columnRepository.findAll();
+		// then
+		SoftAssertions.assertSoftly(softAssertions -> {
+			softAssertions.assertThat(columns.size()).isEqualTo(3);
+			softAssertions.assertAll();
+		});
+	}
 }


### PR DESCRIPTION
## What is this PR? 👓
- `/cards` api 요청시 컬럼별 카드 데이터를 응답하는 API를 구현하였습니다.
- 카드 조회 및 컬럼 조회에 대한 테스트 코드를 구현하였습니다.

## Key changes 🔑
- gradle 의존성에서 `implementation 'org.springframework.boot:spring-boot-starter-jdbc`에서 `implementation 'org.springframework.boot:spring-boot-starter-data-jdbc`으로 의존성을 변경하였습니다.
    - 변경한 이유는 단위 테스트에서 DataJpaTest 애노테이션을 사용하기 위해서입니다.
- 컬럼별 카드 데이터를 조회하기 위해서 CardService.getAllCard 메소드에서 클라이언트에게 전달할 DTO 객체를 변환하는 코드를 구현하였습니다.  
- CardService 객체 초기화시 CardRepository만 선언하였지만 구현할때 ColumnRepoisotory도 필요하게 되어 일부 멤버와 생성자를 변경하였습니다.

## To reviewers 👋
- DataJpaTest 단위 테스트에서 별도의 프로파일 설정을 하지 않고 인텔리제이 실행 설정에서 특정 프로파일로 실행할 수 있도록 하였습니다. 즉, 슬랙의 참고자료에는 @ActiveProfile 애노테이션이 있지만 실제 코드에는 없고 인텔리제이 실행 구성에서 프로파일을 설정하여 테스트하였습니다.

## 테스트 실행 결과
![image](https://github.com/codesquad-team-06/todo-max/assets/33227831/e97b030d-d229-4d14-8244-5ce204c9cf4a)

## `/cards` API 요청 결과
- position 값이 0인 이유는 샘플 데이터의 값을 0으로 설정하였기 때문입니다.

![image](https://github.com/codesquad-team-06/todo-max/assets/33227831/8ce14d24-9738-4260-b9b3-c208ba2e8516)


## Issues
Closes #6
