### PR TITLE
[BE] 예외 처리 매커니즘 구현

### DIFF
--- a/be/src/main/java/codesquad/todo/errors/errorcode/CommonErrorCode.java
+++ b/be/src/main/java/codesquad/todo/errors/errorcode/CommonErrorCode.java
@@ -1,0 +1,31 @@
+package codesquad.todo.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+public enum CommonErrorCode implements ErrorCode {
+	INVALID_INPUT_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 형식입니다."),
+	PAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "페이지를 찾을 수 없습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	CommonErrorCode(HttpStatus httpStatus, String message) {
+		this.httpStatus = httpStatus;
+		this.message = message;
+	}
+
+	@Override
+	public String getName() {
+		return name();
+	}
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return httpStatus;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/be/src/main/java/codesquad/todo/errors/errorcode/ErrorCode.java
+++ b/be/src/main/java/codesquad/todo/errors/errorcode/ErrorCode.java
@@ -1,0 +1,11 @@
+package codesquad.todo.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+	String getName();
+
+	HttpStatus getHttpStatus();
+
+	String getMessage();
+}

--- a/be/src/main/java/codesquad/todo/errors/exception/RestApiException.java
+++ b/be/src/main/java/codesquad/todo/errors/exception/RestApiException.java
@@ -1,0 +1,22 @@
+package codesquad.todo.errors.exception;
+
+import codesquad.todo.errors.errorcode.ErrorCode;
+
+public class RestApiException extends RuntimeException {
+	private final ErrorCode errorCode;
+
+	public RestApiException(ErrorCode errorCode) {
+		this.errorCode = errorCode;
+	}
+
+	public ErrorCode getErrorCode() {
+		return errorCode;
+	}
+
+	@Override
+	public String toString() {
+		return "RestApiException{"
+			+ "errorCode="
+			+ errorCode + '}';
+	}
+}

--- a/be/src/main/java/codesquad/todo/errors/handler/GlobalExceptionHandler.java
+++ b/be/src/main/java/codesquad/todo/errors/handler/GlobalExceptionHandler.java
@@ -1,0 +1,64 @@
+package codesquad.todo.errors.handler;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import codesquad.todo.errors.errorcode.CommonErrorCode;
+import codesquad.todo.errors.errorcode.ErrorCode;
+import codesquad.todo.errors.exception.RestApiException;
+import codesquad.todo.errors.response.ErrorResponse;
+import codesquad.todo.errors.response.ValidationError;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+	private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+	@ExceptionHandler(RestApiException.class)
+	public ResponseEntity<Object> handleRestApiException(RestApiException ex) {
+		log.info("RestApiException handling : {}", ex.toString());
+		return handleExceptionInternal(ex.getErrorCode());
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+		HttpHeaders headers, HttpStatus status, WebRequest request) {
+		log.warn("handleMethodArgumentNotValid", ex);
+		CommonErrorCode errorCode = CommonErrorCode.INVALID_INPUT_FORMAT;
+		return handleExceptionInternal(ex, errorCode);
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
+		return ResponseEntity.status(errorCode.getHttpStatus())
+			.body(makeErrorResponse(errorCode));
+	}
+
+	private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
+		return new ErrorResponse(errorCode, null);
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal(BindException ex, ErrorCode errorCode) {
+		return ResponseEntity.status(errorCode.getHttpStatus()).body(makeErrorResponse(ex, errorCode));
+	}
+
+	private ErrorResponse makeErrorResponse(BindException ex, ErrorCode errorCode) {
+		List<ValidationError> validationErrorList = ex.getBindingResult()
+			.getFieldErrors()
+			.stream()
+			.map(ValidationError::of)
+			.collect(
+				Collectors.toUnmodifiableList());
+		return new ErrorResponse(errorCode, validationErrorList);
+	}
+}

--- a/be/src/main/java/codesquad/todo/errors/response/ErrorResponse.java
+++ b/be/src/main/java/codesquad/todo/errors/response/ErrorResponse.java
@@ -1,0 +1,41 @@
+package codesquad.todo.errors.response;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import codesquad.todo.errors.errorcode.ErrorCode;
+
+public class ErrorResponse {
+	private final String name;
+	private final HttpStatus httpStatus;
+	private final String errorMessage;
+
+	@JsonInclude(value = JsonInclude.Include.NON_NULL)
+	private final List<ValidationError> errors;
+
+	public ErrorResponse(ErrorCode errorCode, List<ValidationError> errors) {
+		this.name = errorCode.getName();
+		this.httpStatus = errorCode.getHttpStatus();
+		this.errorMessage = errorCode.getMessage();
+		this.errors = errors;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public HttpStatus getHttpStatus() {
+		return httpStatus;
+	}
+
+	public String getErrorMessage() {
+		return errorMessage;
+	}
+
+	public List<ValidationError> getErrors() {
+		return errors;
+	}
+}

--- a/be/src/main/java/codesquad/todo/errors/response/ValidationError.java
+++ b/be/src/main/java/codesquad/todo/errors/response/ValidationError.java
@@ -1,0 +1,53 @@
+package codesquad.todo.errors.response;
+
+import java.util.Objects;
+
+import org.springframework.validation.FieldError;
+
+public class ValidationError {
+	private final String field;
+	private final String message;
+
+	public ValidationError(String field, String message) {
+		this.field = field;
+		this.message = message;
+	}
+
+	public ValidationError() {
+		this(null, null);
+	}
+
+	public static ValidationError of(FieldError fieldError) {
+		return new ValidationError(fieldError.getField(), fieldError.getDefaultMessage());
+	}
+
+	public String getField() {
+		return field;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getField(), getMessage());
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof ValidationError)) {
+			return false;
+		}
+		ValidationError that = (ValidationError)obj;
+		return Objects.equals(getField(), that.getField()) && Objects.equals(getMessage(), that.getMessage());
+	}
+
+	@Override
+	public String toString() {
+		return String.format("ValidationError(%s, %s)", field, message);
+	}
+}


### PR DESCRIPTION
## What is this PR? 👓
- 예외 발생 시 클라이언트에게 에러 코드와 메세지를 반환하도록 매커니즘 구현

## Key changes 🔑
- 예외를 나타내는 ErrorCode 열거형과 예외 클래스 구현
- 예외 발생 시 클라이언트에게 반환할 ErrorResponse 작성
- GlobalExceptionHandler 클래스 구현

## To reviewers 👋
- 전체적인 코드 흐름은 네모네모의 이전 코드를 참고하였습니다.
  - [네모네모 깃허브](https://github.com/yonghwankim-dev/be-java-cafe-max/tree/%EB%84%A4%EB%AA%A8%EB%84%A4%EB%AA%A8/src/main/java/kr/codesqaud/cafe/errors)
- View를 반환하는 ErrorHandler Class 부분은 구현하지 않았습니다.
  - 해당 메서드가 필요하다면 추후 구현하면 될 것 같습니다. 

## Issues
Closes #29 