### PR TITLE
[BE] 히스토리 조회 및 삭제 API 구현

### DIFF
--- a/be/src/main/java/codesquad/todo/history/controller/HistoryRestController.java
+++ b/be/src/main/java/codesquad/todo/history/controller/HistoryRestController.java
@@ -24,8 +24,8 @@ public class HistoryRestController {
 	}
 
 	@GetMapping
-	public ResponseEntity<List<HistoryFindAllResponse>> getHistories() {
-		return ResponseEntity.ok().body(historyService.getAll());
+	public List<HistoryFindAllResponse> getHistories() {
+		return historyService.getAll();
 	}
 
 	@DeleteMapping

--- a/be/src/main/java/codesquad/todo/history/controller/HistoryRestController.java
+++ b/be/src/main/java/codesquad/todo/history/controller/HistoryRestController.java
@@ -30,6 +30,6 @@ public class HistoryRestController {
 
 	@DeleteMapping
 	public ResponseEntity<?> deleteAndFetch(@RequestBody HistoryDeleteRequest historyDeleteRequest) {
-		return ResponseEntity.ok(Collections.singletonMap("success", historyService.delete(historyDeleteRequest)));
+		return ResponseEntity.ok(Collections.singletonMap("success", historyService.deleteByIds(historyDeleteRequest)));
 	}
 }

--- a/be/src/main/java/codesquad/todo/history/controller/HistoryRestController.java
+++ b/be/src/main/java/codesquad/todo/history/controller/HistoryRestController.java
@@ -1,15 +1,35 @@
 package codesquad.todo.history.controller;
 
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import codesquad.todo.history.controller.dto.HistoryDeleteRequest;
+import codesquad.todo.history.controller.dto.HistoryFindAllResponse;
 import codesquad.todo.history.service.HistoryService;
 
 @RestController
+@RequestMapping("/histories")
 public class HistoryRestController {
-
 	private final HistoryService historyService;
 
 	public HistoryRestController(HistoryService historyService) {
 		this.historyService = historyService;
+	}
+
+	@GetMapping
+	public ResponseEntity<List<HistoryFindAllResponse>> getHistories() {
+		return ResponseEntity.ok().body(historyService.getAll());
+	}
+
+	@DeleteMapping
+	public ResponseEntity<?> deleteAndFetch(@RequestBody HistoryDeleteRequest historyDeleteRequest) {
+		return ResponseEntity.ok(Collections.singletonMap("success", historyService.delete(historyDeleteRequest)));
 	}
 }

--- a/be/src/main/java/codesquad/todo/history/controller/dto/HistoryDeleteRequest.java
+++ b/be/src/main/java/codesquad/todo/history/controller/dto/HistoryDeleteRequest.java
@@ -1,0 +1,18 @@
+package codesquad.todo.history.controller.dto;
+
+import java.util.List;
+
+public class HistoryDeleteRequest {
+	private List<Long> historyId;
+
+	public HistoryDeleteRequest() {
+	}
+
+	public HistoryDeleteRequest(List<Long> historyId) {
+		this.historyId = historyId;
+	}
+
+	public List<Long> getHistoryId() {
+		return historyId;
+	}
+}

--- a/be/src/main/java/codesquad/todo/history/controller/dto/HistoryFindAllResponse.java
+++ b/be/src/main/java/codesquad/todo/history/controller/dto/HistoryFindAllResponse.java
@@ -1,0 +1,74 @@
+package codesquad.todo.history.controller.dto;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import codesquad.todo.history.entity.History;
+
+public class HistoryFindAllResponse {
+	private final String cardTitle;
+	private final String prevColumn;
+	private final String nextColumn;
+	private final String elapsedTime;
+	private final String actionName;
+
+	public HistoryFindAllResponse(String cardTitle, String prevColumn, String nextColumn, String elapsedTime,
+		String actionName) {
+		this.cardTitle = cardTitle;
+		this.prevColumn = prevColumn;
+		this.nextColumn = nextColumn;
+		this.elapsedTime = elapsedTime;
+		this.actionName = actionName;
+	}
+
+	public static HistoryFindAllResponse from(History history) {
+		return new HistoryFindAllResponse(
+			history.getCardTitle(),
+			history.getPrevColumn(),
+			history.getNextColumn(),
+			calculateElapsedTime(history.getCreatedAt()),
+			history.getAction().getName());
+	}
+
+	public static String calculateElapsedTime(LocalDateTime start) {
+		LocalDateTime now = LocalDateTime.now();
+
+		long minDiff = ChronoUnit.MINUTES.between(start, now);
+		if (minDiff < 60) {
+			return minDiff + "분 전";
+		}
+
+		long hoursDiff = ChronoUnit.HOURS.between(start, now);
+		if (hoursDiff < 24) {
+			return hoursDiff + "시간 전";
+		}
+
+		long daysDiff = ChronoUnit.DAYS.between(start, now);
+		if (daysDiff < 7) {
+			return daysDiff + "일 전";
+		}
+
+		long weeksDiff = daysDiff / 7;
+		return weeksDiff + "주 전";
+	}
+
+	public String getCardTitle() {
+		return cardTitle;
+	}
+
+	public String getPrevColumn() {
+		return prevColumn;
+	}
+
+	public String getNextColumn() {
+		return nextColumn;
+	}
+
+	public String getElapsedTime() {
+		return elapsedTime;
+	}
+
+	public String getActionName() {
+		return actionName;
+	}
+}

--- a/be/src/main/java/codesquad/todo/history/entity/Action.java
+++ b/be/src/main/java/codesquad/todo/history/entity/Action.java
@@ -26,13 +26,13 @@ public class Action {
 
 	@Override
 	public String toString() {
-		return "Action{" +
-			"id=" + id +
-			", name='" + name + '\'' +
-			'}';
+		return "Action{"
+			+ "id=" + id
+			+ ", name='" + name + '\''
+			+ '}';
 	}
 
-	static class Builder {
+	public static class Builder {
 		private Long id;
 		private String name;
 

--- a/be/src/main/java/codesquad/todo/history/entity/History.java
+++ b/be/src/main/java/codesquad/todo/history/entity/History.java
@@ -65,19 +65,19 @@ public class History {
 
 	@Override
 	public String toString() {
-		return "History{" +
-			"id=" + id +
-			", cardTitle='" + cardTitle + '\'' +
-			", prevColumn='" + prevColumn + '\'' +
-			", nextColumn='" + nextColumn + '\'' +
-			", createdAt=" + createdAt +
-			", isDeleted=" + isDeleted +
-			", action=" + action +
-			", cardId=" + cardId +
-			'}';
+		return "History{"
+			+ "id=" + id
+			+ ", cardTitle='" + cardTitle + '\''
+			+ ", prevColumn='" + prevColumn + '\''
+			+ ", nextColumn='" + nextColumn + '\''
+			+ ", createdAt=" + createdAt
+			+ ", isDeleted=" + isDeleted
+			+ ", action=" + action
+			+ ", cardId=" + cardId
+			+ '}';
 	}
 
-	static class Builder {
+	public static class Builder {
 		private Long id;
 		private String cardTitle;
 		private String prevColumn;
@@ -117,7 +117,7 @@ public class History {
 			return this;
 		}
 
-		public Builder actionId(Action action) {
+		public Builder action(Action action) {
 			this.action = action;
 			return this;
 		}

--- a/be/src/main/java/codesquad/todo/history/repository/HistoryRepository.java
+++ b/be/src/main/java/codesquad/todo/history/repository/HistoryRepository.java
@@ -13,7 +13,9 @@ public interface HistoryRepository {
 
 	History modify(History history);
 
-	History deleteById(Long id);
+	int deleteByIds(List<Long> ids);
+
+	int countByIds(List<Long> ids);
 
 	Optional<History> findById(Long id);
 }

--- a/be/src/main/java/codesquad/todo/history/repository/HistoryRepository.java
+++ b/be/src/main/java/codesquad/todo/history/repository/HistoryRepository.java
@@ -15,7 +15,7 @@ public interface HistoryRepository {
 
 	int deleteByIds(List<Long> ids);
 
-	int countByIds(List<Long> ids);
+	int countIds(List<Long> ids);
 
 	Optional<History> findById(Long id);
 }

--- a/be/src/main/java/codesquad/todo/history/repository/JdbcHistoryRepository.java
+++ b/be/src/main/java/codesquad/todo/history/repository/JdbcHistoryRepository.java
@@ -1,18 +1,59 @@
 package codesquad.todo.history.repository;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
+import codesquad.todo.history.entity.Action;
 import codesquad.todo.history.entity.History;
 
 @Repository
 public class JdbcHistoryRepository implements HistoryRepository {
+	private final NamedParameterJdbcTemplate jdbcTemplate;
+	private final RowMapper<History> historyRowMapper = ((rs, rowNum) -> History.builder()
+		.cardTitle(rs.getString("card_title"))
+		.prevColumn(rs.getString("prev_column"))
+		.nextColumn(rs.getString("next_column"))
+		.createAt(rs.getTimestamp("created_at").toLocalDateTime())
+		.action(Action.builder().id(rs.getLong("action_id")).name(rs.getString("action_name")).build())
+		.build()
+	);
+
+	public JdbcHistoryRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
 
 	@Override
 	public List<History> findAll() {
-		return null;
+		String sql =
+			"SELECT h.card_title, h.prev_column, h.next_column, h.created_at, a.id AS action_id, a.name AS action_name "
+				+ "FROM history AS h "
+				+ "JOIN action AS a ON h.action_id = a.id "
+				+ "WHERE h.is_deleted = false "
+				+ "ORDER BY h.id DESC;";
+		return Collections.unmodifiableList(jdbcTemplate.query(sql, historyRowMapper));
+	}
+
+	@Override
+	public int deleteByIds(List<Long> ids) {
+		String sql = "UPDATE history SET is_deleted = true WHERE id IN (:ids)";
+		MapSqlParameterSource parameters = new MapSqlParameterSource();
+		parameters.addValue("ids", ids);
+		return jdbcTemplate.update(sql, parameters); //삭제된 행 개수 반환
+	}
+
+	@Override
+	public int countByIds(List<Long> ids) {
+		String sql = "SELECT COUNT(*) FROM history WHERE id IN (:ids) AND is_deleted = false";
+		MapSqlParameterSource parameters = new MapSqlParameterSource();
+		parameters.addValue("ids", ids);
+		Integer count = jdbcTemplate.queryForObject(sql, parameters, Integer.class);
+		return Optional.ofNullable(count).orElse(0);
 	}
 
 	@Override
@@ -22,11 +63,6 @@ public class JdbcHistoryRepository implements HistoryRepository {
 
 	@Override
 	public History modify(History history) {
-		return null;
-	}
-
-	@Override
-	public History deleteById(Long id) {
 		return null;
 	}
 

--- a/be/src/main/java/codesquad/todo/history/repository/JdbcHistoryRepository.java
+++ b/be/src/main/java/codesquad/todo/history/repository/JdbcHistoryRepository.java
@@ -48,7 +48,7 @@ public class JdbcHistoryRepository implements HistoryRepository {
 	}
 
 	@Override
-	public int countByIds(List<Long> ids) {
+	public int countIds(List<Long> ids) {
 		String sql = "SELECT COUNT(*) FROM history WHERE id IN (:ids) AND is_deleted = false";
 		MapSqlParameterSource parameters = new MapSqlParameterSource();
 		parameters.addValue("ids", ids);

--- a/be/src/main/java/codesquad/todo/history/service/HistoryService.java
+++ b/be/src/main/java/codesquad/todo/history/service/HistoryService.java
@@ -1,8 +1,15 @@
 package codesquad.todo.history.service;
 
-import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.stream.Collectors;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import codesquad.todo.history.controller.dto.HistoryDeleteRequest;
+import codesquad.todo.history.controller.dto.HistoryFindAllResponse;
 import codesquad.todo.history.repository.HistoryRepository;
+
 
 @Service
 public class HistoryService {
@@ -11,5 +18,28 @@ public class HistoryService {
 
 	public HistoryService(HistoryRepository historyRepository) {
 		this.historyRepository = historyRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public List<HistoryFindAllResponse> getAll() {
+		return historyRepository.findAll()
+			.stream()
+			.map(HistoryFindAllResponse::from)
+			.collect(Collectors.toList());
+	}
+
+	@Transactional
+	public boolean delete(HistoryDeleteRequest request) {
+		validate(request);
+		int deletedRows = historyRepository.deleteByIds(request.getHistoryId());
+		return deletedRows > 0;
+	}
+
+	// todo: 추후 Custom Exception으로 변경
+	public void validate(HistoryDeleteRequest request) {
+		int count = historyRepository.countByIds(request.getHistoryId());
+		if (count != request.getHistoryId().size()) {
+			throw new RuntimeException("유효하지 않은 히스토리입니다.");
+		}
 	}
 }

--- a/be/src/main/java/codesquad/todo/history/service/HistoryService.java
+++ b/be/src/main/java/codesquad/todo/history/service/HistoryService.java
@@ -10,7 +10,6 @@ import codesquad.todo.history.controller.dto.HistoryDeleteRequest;
 import codesquad.todo.history.controller.dto.HistoryFindAllResponse;
 import codesquad.todo.history.repository.HistoryRepository;
 
-
 @Service
 public class HistoryService {
 
@@ -30,16 +29,17 @@ public class HistoryService {
 
 	@Transactional
 	public boolean deleteByIds(HistoryDeleteRequest request) {
-		validate(request);
+		if (validate(request)) {
+			throw new RuntimeException("유효하지 않은 히스토리입니다.");
+		}
 		int deletedRows = historyRepository.deleteByIds(request.getHistoryId());
 		return deletedRows > 0;
 	}
 
 	// todo: 추후 Custom Exception으로 변경
-	public void validate(HistoryDeleteRequest request) {
+	@Transactional(readOnly = true)
+	public boolean validate(HistoryDeleteRequest request) {
 		int count = historyRepository.countIds(request.getHistoryId());
-		if (count != request.getHistoryId().size()) {
-			throw new RuntimeException("유효하지 않은 히스토리입니다.");
-		}
+		return count == request.getHistoryId().size();
 	}
 }

--- a/be/src/main/java/codesquad/todo/history/service/HistoryService.java
+++ b/be/src/main/java/codesquad/todo/history/service/HistoryService.java
@@ -29,7 +29,7 @@ public class HistoryService {
 	}
 
 	@Transactional
-	public boolean delete(HistoryDeleteRequest request) {
+	public boolean deleteByIds(HistoryDeleteRequest request) {
 		validate(request);
 		int deletedRows = historyRepository.deleteByIds(request.getHistoryId());
 		return deletedRows > 0;
@@ -37,7 +37,7 @@ public class HistoryService {
 
 	// todo: 추후 Custom Exception으로 변경
 	public void validate(HistoryDeleteRequest request) {
-		int count = historyRepository.countByIds(request.getHistoryId());
+		int count = historyRepository.countIds(request.getHistoryId());
 		if (count != request.getHistoryId().size()) {
 			throw new RuntimeException("유효하지 않은 히스토리입니다.");
 		}

--- a/be/src/test/java/codesquad/todo/history/controller/HistoryRestControllerTest.java
+++ b/be/src/test/java/codesquad/todo/history/controller/HistoryRestControllerTest.java
@@ -5,29 +5,36 @@ import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import codesquad.todo.history.controller.dto.HistoryDeleteRequest;
 import codesquad.todo.history.controller.dto.HistoryFindAllResponse;
 import codesquad.todo.history.service.HistoryService;
 
 @WebMvcTest(HistoryRestController.class)
 class HistoryRestControllerTest {
 	@Autowired
+	ObjectMapper objectMapper;
+	@Autowired
 	private MockMvc mockMvc;
-
 	@MockBean
 	private HistoryService historyService;
 
 	@Test
-	@DisplayName("활동 기록 목록을 불러오고 Json 형태로 데이터를 반환한다.")
+	@DisplayName("활동 기록 목록을 불러오고 Json 타입으로 데이터를 반환한다.")
 	public void shouldReturnAllHistories() throws Exception {
 		//given
 		HistoryFindAllResponse history1 = new HistoryFindAllResponse("Card Title 5", "3", "3", "5일 전", "수정");
@@ -50,4 +57,22 @@ class HistoryRestControllerTest {
 			.andExpect(jsonPath("$[*].actionName").value(
 				hasItems(histories.stream().map(HistoryFindAllResponse::getActionName).toArray())));
 	}
+
+	@Test
+	@DisplayName("유효한 활동 기록 id를 전달 받으면 해당 기록의 is_deleted 값을 바꾸고 성공 메세지를 Json 타입으로 반환한다.")
+	public void shouldDeleteHistories() throws Exception {
+		//given
+		List<Long> ids = new ArrayList<>(Arrays.asList(4L, 5L, 6L));
+		HistoryDeleteRequest request = new HistoryDeleteRequest(ids);
+		when(historyService.deleteByIds(ArgumentMatchers.any(HistoryDeleteRequest.class))).thenReturn(true);
+
+		//when & then
+		mockMvc.perform(delete("/histories")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success", is(true)));
+	}
+
+	// todo: 추후 예외 발생 테스트 코드 작성
 }

--- a/be/src/test/java/codesquad/todo/history/controller/HistoryRestControllerTest.java
+++ b/be/src/test/java/codesquad/todo/history/controller/HistoryRestControllerTest.java
@@ -1,5 +1,53 @@
 package codesquad.todo.history.controller;
 
-class HistoryRestControllerTest {
+import static org.hamcrest.Matchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import codesquad.todo.history.controller.dto.HistoryFindAllResponse;
+import codesquad.todo.history.service.HistoryService;
+
+@WebMvcTest(HistoryRestController.class)
+class HistoryRestControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private HistoryService historyService;
+
+	@Test
+	@DisplayName("활동 기록 목록을 불러오고 Json 형태로 데이터를 반환한다.")
+	public void shouldReturnAllHistories() throws Exception {
+		//given
+		HistoryFindAllResponse history1 = new HistoryFindAllResponse("Card Title 5", "3", "3", "5일 전", "수정");
+		HistoryFindAllResponse history2 = new HistoryFindAllResponse("Card Title 4", "1", "2", "1주 전", "이동");
+		List<HistoryFindAllResponse> histories = Arrays.asList(history1, history2);
+		given(historyService.getAll()).willReturn(histories);
+
+		//when & then
+		mockMvc.perform(get("/histories"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.size()").value(histories.size()))
+			.andExpect(jsonPath("$[*].cardTitle").value(
+				hasItems(histories.stream().map(HistoryFindAllResponse::getCardTitle).toArray())))
+			.andExpect(jsonPath("$[*].prevColumn").value(
+				hasItems(histories.stream().map(HistoryFindAllResponse::getPrevColumn).toArray())))
+			.andExpect(jsonPath("$[*].nextColumn").value(
+				hasItems(histories.stream().map(HistoryFindAllResponse::getNextColumn).toArray())))
+			.andExpect(jsonPath("$[*].elapsedTime").value(
+				hasItems(histories.stream().map(HistoryFindAllResponse::getElapsedTime).toArray())))
+			.andExpect(jsonPath("$[*].actionName").value(
+				hasItems(histories.stream().map(HistoryFindAllResponse::getActionName).toArray())));
+	}
 }

--- a/be/src/test/java/codesquad/todo/history/entity/ActionTest.java
+++ b/be/src/test/java/codesquad/todo/history/entity/ActionTest.java
@@ -1,5 +1,0 @@
-package codesquad.todo.history.entity;
-
-class ActionTest {
-
-}

--- a/be/src/test/java/codesquad/todo/history/entity/HistoryTest.java
+++ b/be/src/test/java/codesquad/todo/history/entity/HistoryTest.java
@@ -1,5 +1,0 @@
-package codesquad.todo.history.entity;
-
-class HistoryTest {
-
-}

--- a/be/src/test/java/codesquad/todo/history/repository/JdbcHistoryRepositoryTest.java
+++ b/be/src/test/java/codesquad/todo/history/repository/JdbcHistoryRepositoryTest.java
@@ -1,5 +1,37 @@
 package codesquad.todo.history.repository;
 
-class JdbcHistoryRepositoryTest {
+import java.util.List;
 
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.stereotype.Repository;
+
+import codesquad.todo.history.entity.History;
+
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION,
+	classes = Repository.class))
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class JdbcHistoryRepositoryTest {
+	@Autowired
+	private HistoryRepository historyRepository;
+
+	@Test
+	@DisplayName("is_deleted = false인 모든 활동 기록을 불러온다.")
+	public void testFindAll() {
+		//given
+
+		//when
+		List<History> historyList = historyRepository.findAll();
+
+		//then
+		SoftAssertions.assertSoftly(softAssertions -> {
+			softAssertions.assertThat(historyList.size()).isEqualTo(7);
+		});
+	}
 }

--- a/be/src/test/java/codesquad/todo/history/repository/JdbcHistoryRepositoryTest.java
+++ b/be/src/test/java/codesquad/todo/history/repository/JdbcHistoryRepositoryTest.java
@@ -1,5 +1,7 @@
 package codesquad.todo.history.repository;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.assertj.core.api.SoftAssertions;
@@ -32,6 +34,36 @@ class JdbcHistoryRepositoryTest {
 		//then
 		SoftAssertions.assertSoftly(softAssertions -> {
 			softAssertions.assertThat(historyList.size()).isEqualTo(7);
+		});
+	}
+
+	@Test
+	@DisplayName("전달 받은 활동 기록 아이디가 모두 유효한 지 확인한다.")
+	public void testCountIds() {
+		//given
+		List<Long> ids = new ArrayList<>(Arrays.asList(4L, 5L, 6L));
+
+		//when
+		int validIds = historyRepository.countByIds(ids);
+
+		//then
+		SoftAssertions.assertSoftly(softAssertions -> {
+			softAssertions.assertThat(validIds).isEqualTo(3);
+		});
+	}
+
+	@Test
+	@DisplayName("활동 기록 아이디에 따라 해당 기록의 is_deleted 값을 false로 변경하고 변경된 레코드 수를 반환한다.")
+	public void testDeleteByIds() {
+		//given
+		List<Long> ids = new ArrayList<>(Arrays.asList(4L, 5L, 6L));
+
+		//when
+		int deletedHistories = historyRepository.deleteByIds(ids);
+
+		//then
+		SoftAssertions.assertSoftly(softAssertions -> {
+			softAssertions.assertThat(deletedHistories).isEqualTo(3);
 		});
 	}
 }

--- a/be/src/test/java/codesquad/todo/history/repository/JdbcHistoryRepositoryTest.java
+++ b/be/src/test/java/codesquad/todo/history/repository/JdbcHistoryRepositoryTest.java
@@ -44,7 +44,7 @@ class JdbcHistoryRepositoryTest {
 		List<Long> ids = new ArrayList<>(Arrays.asList(4L, 5L, 6L));
 
 		//when
-		int validIds = historyRepository.countByIds(ids);
+		int validIds = historyRepository.countIds(ids);
 
 		//then
 		SoftAssertions.assertSoftly(softAssertions -> {

--- a/be/src/test/java/codesquad/todo/history/service/HistoryServiceTest.java
+++ b/be/src/test/java/codesquad/todo/history/service/HistoryServiceTest.java
@@ -1,5 +1,0 @@
-package codesquad.todo.history.service;
-
-class HistoryServiceTest {
-
-}


### PR DESCRIPTION
## What is this PR? 👓
- 활동 기록 목록 조회 시 `is_deleted = false`인 기록들을 반환하는 API 구현
  - 관련 테스트 코드 작성
- 활동 기록 목록 삭제하는 API 구현 
  - 예외 관련 테스트 코드를 제외한 테스트 코드 작성  

## Key changes 🔑
- DB의 created_at 시간 값을 String 타입으로 변환하기 위해 `HistoryFindAllResponse` 클래스에 `calculateElapsedTime` 메서드 작성
- `deletedByIds`의 파라미터로 List<Long> 타입 전달
- 목록 삭제 시 파라미터로 전달 받은 id 개수와 전달 받은 id 중 DB에 존재하면서 `is_deleted = false`인 id의 개수를 비교
  -  유효하지 않은 id가 있는 경우 불일치하므로 예외 발생

## To reviewers 👋
- 목록 삭제 기능에서 유효하지 않은 id 요청 시 `RuntimeException` 예외를 발생 시켰습니다.
  - 추후 예외 발생(Json 타입 반환) 수정과 함께 예외 관련 테스트 코드도 작성할 예정입니다.

## 테스트 실행 결과
![image](https://github.com/codesquad-team-06/todo-max/assets/107015624/5b935616-0ae9-4b9a-8546-e0b592e2c678)

## `/histories` API 요청 결과
![image](https://github.com/codesquad-team-06/todo-max/assets/107015624/f05cb4b0-e88a-4414-b3c5-ba2c40c86cc4)

## Issues
Closes #5