### PR TITLE
[FE] 카드 등록 기능 작업 마무리 및 활동 기록 레이어 기능 구현 PR

### DIFF
--- a/frontend/src/components/ActivityHistory.tsx
+++ b/frontend/src/components/ActivityHistory.tsx
@@ -14,7 +14,11 @@ type History = {
   actionName: string;
 };
 
-export default function ActivityHistory() {
+export default function ActivityHistory({
+  toggleHistory,
+}: {
+  toggleHistory: () => void;
+}) {
   const { openModal, closeModal } = useContext(ModalContext);
   const [history, setHistory] = useState<History[]>([]);
 
@@ -81,37 +85,43 @@ export default function ActivityHistory() {
         </CloseBtn>
       </TitleContainer>
       <ListContainer>
-        {history.map(
-          ({
-            id,
-            cardTitle,
-            prevColumn,
-            nextColumn,
-            timestamp,
-            actionName,
-          }) => (
-            <ActivityHistoryItem
-              {...{
-                key: id,
-                cardTitle,
-                prevColumn,
-                nextColumn,
-                timestamp,
-                actionName,
-              }}
-            />
-          )
+        {history.length === 0 && (
+          <EmptyHistoryItem>사용자 활동 기록이 없습니다.</EmptyHistoryItem>
         )}
+        {history.length !== 0 &&
+          history.map(
+            ({
+              id,
+              cardTitle,
+              prevColumn,
+              nextColumn,
+              timestamp,
+              actionName,
+            }) => (
+              <ActivityHistoryItem
+                {...{
+                  key: id,
+                  cardTitle,
+                  prevColumn,
+                  nextColumn,
+                  timestamp,
+                  actionName,
+                }}
+              />
+            )
+          )}
       </ListContainer>
-      <ButtonContainer>
-        <button
-          type="submit"
-          onClick={() =>
-            openModal("모든 사용자 활동 기록을 삭제할까요?", handleSubmit)
-          }>
-          기록 전체 삭제
-        </button>
-      </ButtonContainer>
+      {history.length !== 0 && (
+        <ButtonContainer>
+          <button
+            type="submit"
+            onClick={() =>
+              openModal("모든 사용자 활동 기록을 삭제할까요?", handleSubmit)
+            }>
+            기록 전체 삭제
+          </button>
+        </ButtonContainer>
+      )}
     </Layer>
   );
 }
@@ -175,4 +185,15 @@ const ButtonContainer = styled.div`
     color: ${({ theme: { colors } }) => colors.red};
     cursor: pointer;
   }
+`;
+
+const EmptyHistoryItem = styled.li`
+  width: 100%;
+  padding: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  font: ${({ theme: { font } }) => font.displayMD14};
+  color: ${({ theme: { colors } }) => colors.grey500};
 `;

--- a/frontend/src/components/ActivityHistory.tsx
+++ b/frontend/src/components/ActivityHistory.tsx
@@ -79,7 +79,7 @@ export default function ActivityHistory({
     <Layer>
       <TitleContainer>
         <h3>사용자 활동 기록</h3>
-        <CloseBtn onClick={closeModal}>
+        <CloseBtn onClick={toggleHistory}>
           <img src={closeButtonIcon} alt="닫기 버튼" />
           <span>닫기</span>
         </CloseBtn>

--- a/frontend/src/components/ActivityHistory.tsx
+++ b/frontend/src/components/ActivityHistory.tsx
@@ -89,27 +89,14 @@ export default function ActivityHistory({
           <EmptyHistoryItem>사용자 활동 기록이 없습니다.</EmptyHistoryItem>
         )}
         {history.length !== 0 &&
-          history.map(
-            ({
-              id,
-              cardTitle,
-              prevColumn,
-              nextColumn,
-              timestamp,
-              actionName,
-            }) => (
-              <ActivityHistoryItem
-                {...{
-                  key: id,
-                  cardTitle,
-                  prevColumn,
-                  nextColumn,
-                  timestamp,
-                  actionName,
-                }}
-              />
-            )
-          )}
+          history.map((historyItem) => (
+            <ActivityHistoryItem
+              {...{
+                key: historyItem.id,
+                historyItem,
+              }}
+            />
+          ))}
       </ListContainer>
       {history.length !== 0 && (
         <ButtonContainer>
@@ -128,8 +115,8 @@ export default function ActivityHistory({
 
 const Layer = styled.div`
   position: absolute;
-  top: 64px;
-  right: 60px;
+  top: 50px;
+  right: 50px;
 
   width: 366px;
   padding: 8px;

--- a/frontend/src/components/ActivityHistoryItem.tsx
+++ b/frontend/src/components/ActivityHistoryItem.tsx
@@ -2,17 +2,15 @@ import React from "react";
 import { styled } from "styled-components";
 
 export default function ActivityHistoryItem({
-  cardTitle,
-  prevColumn,
-  nextColumn,
-  timestamp,
-  actionName,
+  historyItem: { cardTitle, prevColumn, nextColumn, timestamp, actionName },
 }: {
-  cardTitle: string;
-  prevColumn: string;
-  nextColumn: string;
-  timestamp: string;
-  actionName: string;
+  historyItem: {
+    cardTitle: string;
+    prevColumn: string;
+    nextColumn: string;
+    timestamp: string;
+    actionName: string;
+  };
 }) {
   return (
     <StyledItem>

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -41,7 +41,6 @@ export default function Board() {
     columnId,
   }: Card) => {
     setBoard((prevBoard: ColumnData[]) => {
-      const newBoard: ColumnData[] = [...prevBoard];
       const newCard = {
         id,
         title,
@@ -49,10 +48,16 @@ export default function Board() {
         position,
         columnId,
       };
-      const columnIndex = columnId - 1;
 
-      const updatedCardList = [newCard, ...newBoard[columnIndex].cards];
-      newBoard[columnIndex].cards = updatedCardList;
+      const newBoard: ColumnData[] = [...prevBoard].map((column) => {
+        if (column.columnId === columnId) {
+          return {
+            ...column,
+            cards: [newCard, ...column.cards],
+          };
+        }
+        return column;
+      });
 
       return newBoard;
     });

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -1,10 +1,17 @@
 /* eslint-disable no-alert */
 import React, { useState, useEffect } from "react";
 import { styled } from "styled-components";
-import Column, { Card } from "./Column.tsx";
+import Column from "./Column.tsx";
+import { Card } from "../types.ts";
+
+type ColumnData = {
+  columnId: number;
+  name: string;
+  cards: Card[];
+};
 
 export default function Board() {
-  const [board, setBoard] = useState([]);
+  const [board, setBoard] = useState<ColumnData[]>([]);
 
   useEffect(() => {
     const fetchBoard = async () => {
@@ -26,6 +33,27 @@ export default function Board() {
     fetchBoard();
   }, []);
 
+  const addNewCardHandler = ({
+    id,
+    title,
+    content,
+    position,
+    columnId,
+  }: Card) => {
+    setBoard((prevBoard: ColumnData[]) => {
+      const newBoard: ColumnData[] = [...prevBoard];
+      const newCard = {
+        id,
+        title,
+        content,
+        position,
+        columnId,
+      };
+      newBoard[columnId - 1].cards.push(newCard);
+      return newBoard;
+    });
+  };
+
   return (
     <StyledBoard>
       {board.map(
@@ -38,7 +66,7 @@ export default function Board() {
           name: string;
           cards: Card[];
         }) => (
-          <Column {...{ key: columnId, name, cards }} />
+          <Column {...{ key: columnId, name, cards, addNewCardHandler }} />
         )
       )}
     </StyledBoard>

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -49,7 +49,11 @@ export default function Board() {
         position,
         columnId,
       };
-      newBoard[columnId - 1].cards.push(newCard);
+      const columnIndex = columnId - 1;
+
+      const updatedCardList = [newCard, ...newBoard[columnIndex].cards];
+      newBoard[columnIndex].cards = updatedCardList;
+
       return newBoard;
     });
   };

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -33,24 +33,10 @@ export default function Board() {
     fetchBoard();
   }, []);
 
-  const addNewCardHandler = ({
-    id,
-    title,
-    content,
-    position,
-    columnId,
-  }: Card) => {
+  const addNewCardHandler = (newCard: Card) => {
     setBoard((prevBoard: ColumnData[]) => {
-      const newCard = {
-        id,
-        title,
-        content,
-        position,
-        columnId,
-      };
-
-      const newBoard: ColumnData[] = [...prevBoard].map((column) => {
-        if (column.columnId === columnId) {
+      const newBoard: ColumnData[] = prevBoard.map((column) => {
+        if (column.columnId === newCard.columnId) {
           return {
             ...column,
             cards: [newCard, ...column.cards],

--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -5,21 +5,16 @@ import NewColumnCard from "./ColumnCard/NewColumnCard.tsx";
 import IconButton from "./common/IconButton.tsx";
 import addButtonIcon from "../assets/plus.svg";
 import deleteButtonIcon from "../assets/closed.svg";
-
-export type Card = {
-  id: number;
-  title: string;
-  content: string;
-  position: number;
-  columnId: number;
-};
+import { Card } from "../types.ts";
 
 export default function Column({
   name,
   cards,
+  addNewCardHandler,
 }: {
   name: string;
   cards: Card[];
+  addNewCardHandler: (card: Card) => void;
 }) {
   const [isNewCardActive, setIsNewCardActive] = useState(false);
 
@@ -50,7 +45,9 @@ export default function Column({
       </Header>
 
       <ul className="cards-list">
-        {isNewCardActive && <NewColumnCard {...{ toggleNewCard }} />}
+        {isNewCardActive && (
+          <NewColumnCard {...{ toggleNewCard, addNewCardHandler }} />
+        )}
 
         {cards.map(({ id, title, content }) => (
           <ColumnCard {...{ key: id, id, title, content }} />

--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -27,7 +27,7 @@ export default function Column({
       <Header>
         <div className="column-info-container">
           <h2>{name}</h2>
-          <span>{cards.length}</span>
+          <span>{cards.length < 100 ? cards.length : "99+"}</span>
         </div>
         <div className="buttons-container">
           <IconButton

--- a/frontend/src/components/ColumnCard/ColumnCardMode.tsx
+++ b/frontend/src/components/ColumnCard/ColumnCardMode.tsx
@@ -2,6 +2,7 @@
 import React, { useState, ChangeEvent, FormEvent } from "react";
 import { styled } from "styled-components";
 import ActionButton from "../common/ActionButton.tsx";
+import { Card } from "../../types.ts";
 
 const ModeKR = {
   add: "등록",
@@ -11,6 +12,7 @@ const ModeKR = {
 ColumnCardMode.defaultProps = {
   toggleEditMode: undefined,
   toggleNewCard: undefined,
+  addNewCardHandler: undefined,
   cardDetails: {},
 };
 
@@ -19,6 +21,7 @@ export default function ColumnCardMode({
   cardDetails,
   toggleEditMode,
   toggleNewCard,
+  addNewCardHandler,
 }: {
   mode: "add" | "edit";
   cardDetails?: {
@@ -28,6 +31,7 @@ export default function ColumnCardMode({
   };
   toggleEditMode?: () => void;
   toggleNewCard?: () => void;
+  addNewCardHandler?: (card: Card) => void;
 }) {
   const [newCardTitle, setNewCardTitle] = useState(
     mode === "add" ? "" : cardDetails?.title
@@ -107,6 +111,8 @@ export default function ColumnCardMode({
           await addNewCardRequest();
         // TODO: Update board state
         toggleNewCard && toggleNewCard();
+        addNewCardHandler &&
+          addNewCardHandler({ id, title, content, position, columnId });
       } else if (mode === "edit") {
         const { id, title, content } = await editCardRequest();
         // TODO: Update board state

--- a/frontend/src/components/ColumnCard/ColumnCardMode.tsx
+++ b/frontend/src/components/ColumnCard/ColumnCardMode.tsx
@@ -107,12 +107,9 @@ export default function ColumnCardMode({
 
     try {
       if (mode === "add") {
-        const { id, title, content, position, columnId } =
-          await addNewCardRequest();
-        // TODO: Update board state
+        const newCard = await addNewCardRequest();
+        addNewCardHandler && addNewCardHandler(newCard);
         toggleNewCard && toggleNewCard();
-        addNewCardHandler &&
-          addNewCardHandler({ id, title, content, position, columnId });
       } else if (mode === "edit") {
         const { id, title, content } = await editCardRequest();
         // TODO: Update board state

--- a/frontend/src/components/ColumnCard/NewColumnCard.tsx
+++ b/frontend/src/components/ColumnCard/NewColumnCard.tsx
@@ -1,15 +1,18 @@
 import React from "react";
 import { styled } from "styled-components";
 import ColumnCardMode from "./ColumnCardMode.tsx";
+import { Card } from "../../types.ts";
 
 export default function NewColumnCard({
   toggleNewCard,
+  addNewCardHandler,
 }: {
   toggleNewCard: () => void;
+  addNewCardHandler: (card: Card) => void;
 }) {
   return (
     <StyledNewColumnCard>
-      <ColumnCardMode {...{ mode: "add", toggleNewCard }} />
+      <ColumnCardMode {...{ mode: "add", toggleNewCard, addNewCardHandler }} />
     </StyledNewColumnCard>
   );
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,10 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 import { styled } from "styled-components";
 import ActivityHistory from "./ActivityHistory.tsx";
 import IconButton from "./common/IconButton.tsx";
 import historyButtonIcon from "../assets/history.svg";
 
 export default function Header() {
+  const [isHistoryActive, setIsHistoryActive] = useState(false);
+
+  const toggleHistory = () => {
+    setIsHistoryActive(!isHistoryActive);
+  };
+
   return (
     <>
       <StyledHeader>
@@ -13,9 +19,10 @@ export default function Header() {
           className="history-button"
           src={historyButtonIcon}
           alt="사용자 활동 기록 조회"
+          onClick={toggleHistory}
         />
       </StyledHeader>
-      <ActivityHistory />
+      {isHistoryActive && <ActivityHistory {...{ toggleHistory }} />}
     </>
   );
 }

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -122,9 +122,9 @@ const board = [
 // 추가 요청 성공
 const successCardAdd = {
   card: {
-    id: 1,
-    title: "ERD 설계하기",
-    content: "팀원들과 협업하여 ERD 설계 완성하기",
+    id: 10,
+    title: "식재료 주문하기",
+    content: "쿠팡에서 필요한 것들 주문",
     position: 1024,
     columnId: 1,
   },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,7 @@
+export type Card = {
+  id: number;
+  title: string;
+  content: string;
+  position: number;
+  columnId: number;
+};


### PR DESCRIPTION
## What is this PR? 👓
- 사용자 활동기록 레이어 토글 기능 및 디폴트 문구 출력 기능
- 새로운 카드 등록시 화면에 새로운 카드가 렌더링 되는 기능

## Key changes 🔑
- `Header` 컴포넌트의 state에 따라 `ActivityHistory` 컴포넌트 조건부 렌더링
- `ActivityHistoryItem`이 없을 때 렌더링 되는 UI 구현
- `Board`에 addNewCardHandler 함수 추가 후 하위 컴포넌트들에 props로 전달

## To reviewers 👋
- addNewCardHandler가 edit에서도 비슷하게 쓰일 수 있을 것 같아서 한 번 확인 부탁드립니다.

## Issues
Closes #40 