### PR TITLE
[BE] 표준 출력과 에러 출력을 로그 분리하여 저장

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -3,11 +3,12 @@ cd ~/todo-max/be                                                      # be 디�
 sudo chmod +x ./gradlew                                               # gradlew에 실행 권한 부여
 ./gradlew clean build -x test                                         # 테스트 없이 빌드
 cd build/libs/                                                        # build/libs/ 디렉토리로 이동
-nohup java -Dspring.profiles.active=prod -jar *.jar >~/log.txt 2>&1 & # prod 프로파일로 스프링 실행, 로그는 ~/log.txt에 저장, 백그라운드로 실행
+nohup java -Dspring.profiles.active=prod -jar *.jar 1>~/log.out 2>~/err.out & # prod 프로파일로 스프링 실행,
+# 표준 출력 로그는 ~/log.out에, 에러 출력 로그는 ~/err.out에 저장, 백그라운드로 실행
 
 # react web 실행
 cd ~/todo-max/frontend
 npm install                               # node_modules
 npm run build                             # 리액트 빌드
 npm install -g serve                      # serve 설치
-nohup serve -s build >~/fe-log.txt 2>&1 & # 백그라운드 실행
+nohup serve -s build 1>~/fe-log.out 2>~/fe-err.out & # 백그라운드 실행


### PR DESCRIPTION
## What is this PR? 👓
- jar 파일 실행시 표준 출력과 에러 출력에 대한 내용을 하나의 log.txt 파일이 아닌 분리하여 저장하도록 스크립트를 수정하였습니다.

## Key changes 🔑
- deploy.sh 파일에 로그 저장시 표준 출력은 log.out 파일에 저장하도록 스크립트를 수정합니다.
- deploy.sh 파일에 로그 저장시 에러 출력은 err.out 파일에 저장하도록 스크립트를 수정합니다.

## To reviewers 👋

## Issues
Closes #44 
