### PR TITLE
[BE] be 브랜치 코드 중복 제거 및 테스트 코드 모킹 문제 해결

### DIFF
--- a/be/src/main/java/codesquad/todo/card/controller/dto/CardMoveResponse.java
+++ b/be/src/main/java/codesquad/todo/card/controller/dto/CardMoveResponse.java
@@ -22,8 +22,4 @@ public class CardMoveResponse {
 	public boolean isSuccess() {
 		return success;
 	}
-
-	public static CardMoveResponse from(Card card) {
-		return new CardMoveResponse(CardResponseDTO.from(card), true);
-	}
 }

--- a/be/src/test/java/codesquad/todo/column/controller/ColumnRestControllerTest.java
+++ b/be/src/test/java/codesquad/todo/column/controller/ColumnRestControllerTest.java
@@ -25,6 +25,8 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import codesquad.todo.column.service.ColumnService;
+import codesquad.todo.errors.errorcode.ColumnErrorCode;
+import codesquad.todo.errors.exception.RestApiException;
 import codesquad.todo.errors.handler.GlobalExceptionHandler;
 
 @WebMvcTest(controllers = {ColumnRestController.class})
@@ -170,6 +172,8 @@ class ColumnRestControllerTest {
 			// given
 			String columnId = "9999";
 			// mocking
+			when(columnService.deleteColumn(Long.valueOf(columnId))).thenThrow(
+				new RestApiException(ColumnErrorCode.NOT_FOUND_COLUMN));
 			// when
 			mockMvc.perform(delete("/column/" + columnId))
 				.andExpect(status().isNotFound())
@@ -284,10 +288,9 @@ class ColumnRestControllerTest {
 			// given
 			Long columnId = 9999L;
 			ColumnModifyRequest modifyRequest = new ColumnModifyRequest(columnId, "수정된 제목");
-			ColumnSaveDto columnSaveDto = new ColumnSaveDto(columnId, "수정된 제목");
 			String body = objectMapper.writeValueAsString(modifyRequest);
 			// mocking
-			when(columnService.modifyColumn(any())).thenReturn(columnSaveDto);
+			when(columnService.modifyColumn(any())).thenThrow(new RestApiException(ColumnErrorCode.NOT_FOUND_COLUMN));
 			// when
 			mockMvc.perform(put("/column/" + columnId)
 					.content(body)


### PR DESCRIPTION
## What is this PR? 👓
- be 브랜치의 코드 중복 제거 및 테스트 코드 모킹 재설정

## Key changes 🔑
- CardMoveResponse 클래스에서 중복된 코드를 제거하였습니다.
- 컬럼 관련 테스트 코드에서 잘못된 모킹 설정을 해결하였습니다.

## To reviewers 👋

## Issues
Closes #71 
