### PR TITLE
[BE] 카드 조회 서비스 리팩토링

### DIFF
--- a/be/src/main/java/codesquad/todo/card/controller/CardListResponse.java
+++ b/be/src/main/java/codesquad/todo/card/controller/CardListResponse.java
@@ -25,4 +25,13 @@ public class CardListResponse {
 	public List<CardSearchResponse> getCards() {
 		return cards;
 	}
+
+	@Override
+	public String toString() {
+		return "CardListResponse{" +
+			"cards=" + cards +
+			", columnId=" + columnId +
+			", name='" + name + '\'' +
+			'}';
+	}
 }

--- a/be/src/main/java/codesquad/todo/card/controller/dto/CardMoveResponse.java
+++ b/be/src/main/java/codesquad/todo/card/controller/dto/CardMoveResponse.java
@@ -23,7 +23,4 @@ public class CardMoveResponse {
 		return success;
 	}
 
-	public static CardMoveResponse from(Card card) {
-		return new CardMoveResponse(CardResponseDTO.from(card), true);
-	}
 }

--- a/be/src/test/java/codesquad/todo/card/service/CardServiceTest.java
+++ b/be/src/test/java/codesquad/todo/card/service/CardServiceTest.java
@@ -1,5 +1,82 @@
 package codesquad.todo.card.service;
 
-class CardServiceTest {
+import java.util.ArrayList;
+import java.util.List;
 
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import codesquad.todo.card.controller.CardListResponse;
+import codesquad.todo.card.entity.Card;
+import codesquad.todo.card.repository.CardRepository;
+import codesquad.todo.column.entity.Column;
+import codesquad.todo.column.repository.ColumnRepository;
+import codesquad.todo.history.repository.HistoryRepository;
+
+@SpringBootTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CardServiceTest {
+	@Autowired
+	private CardService cardService;
+
+	@Autowired
+	private HistoryRepository historyRepository;
+
+	@Mock
+	private CardRepository cardRepository;
+
+	@Mock
+	private ColumnRepository columnRepository;
+
+	@Test
+	@DisplayName("모든 카드를 요청할때 컬럼명 카드를 응답합니다.")
+	public void testGetAllCard() {
+		// given
+		Long[] ids = {1L, 2L, 3L};
+		List<Column> mockColumns = new ArrayList<>();
+		mockColumns.add(Column.builder().id(ids[0]).name("해야할 일").build());
+		mockColumns.add(Column.builder().id(ids[1]).name("하고 있는 일").build());
+		mockColumns.add(Column.builder().id(ids[2]).name("완료한 일").build());
+
+		List<Card> mockCardsByColumnId1 = new ArrayList<>();
+		mockCardsByColumnId1.add(Card.builder().id(1L).title("제목1").content("내용1").position(1024).build());
+		mockCardsByColumnId1.add(Card.builder().id(2L).title("제목2").content("내용2").position(2048).build());
+		mockCardsByColumnId1.add(Card.builder().id(3L).title("제목3").content("내용3").position(3072).build());
+
+		List<Card> mockCardsByColumnId2 = new ArrayList<>();
+		mockCardsByColumnId1.add(Card.builder().id(4L).title("제목4").content("내용4").position(1024).build());
+		mockCardsByColumnId1.add(Card.builder().id(5L).title("제목5").content("내용5").position(2048).build());
+		mockCardsByColumnId1.add(Card.builder().id(6L).title("제목6").content("내용6").position(3072).build());
+
+		List<Card> mockCardsByColumnId3 = new ArrayList<>();
+		mockCardsByColumnId1.add(Card.builder().id(7L).title("제목7").content("내용7").position(1024).build());
+		mockCardsByColumnId1.add(Card.builder().id(8L).title("제목8").content("내용8").position(2048).build());
+		mockCardsByColumnId1.add(Card.builder().id(9L).title("제목9").content("내용3").position(3072).build());
+
+		// mocking
+		Mockito.when(columnRepository.findAll()).thenReturn(mockColumns);
+		Mockito.when(cardRepository.findAllByColumnId(ids[0])).thenReturn(mockCardsByColumnId1);
+		Mockito.when(cardRepository.findAllByColumnId(ids[1])).thenReturn(mockCardsByColumnId2);
+		Mockito.when(cardRepository.findAllByColumnId(ids[2])).thenReturn(mockCardsByColumnId3);
+		// when
+		List<CardListResponse> responses = cardService.getAllCard();
+		// then
+		CardListResponse response = responses.get(0);
+		SoftAssertions.assertSoftly(softAssertions -> {
+			softAssertions.assertThat(response.getColumnId()).isEqualTo(1L);
+			softAssertions.assertThat(response.getName()).isEqualTo("해야할 일");
+			softAssertions.assertThat(response.getCards().get(0).getId()).isEqualTo(3L);
+			softAssertions.assertThat(response.getCards().get(1).getId()).isEqualTo(2L);
+			softAssertions.assertThat(response.getCards().get(2).getId()).isEqualTo(1L);
+			softAssertions.assertAll();
+		});
+		responses.forEach(System.out::println);
+	}
 }


### PR DESCRIPTION
## What is this PR? 👓
- 카드 조회시 쿼리를 더 적게 호출하도록 리팩토링하였습니다.

## Key changes 🔑
- 기존 컬럼 아이디별로 카드를 조회할때 쿼리하는 것에서 모든 카드를 조회하는 방식으로 변경되었습니다.

## To reviewers 👋
- be 브랜치에서 새로운 브랜치를 생성했을때 CardMoveResponse 클래스에 중복된 메소드 코드가 존재하여 제거하였습니다.
- 카드 조회 서비스에 대한 테스트 코드를 작성하였습니다.

## Issues
Close #80 
